### PR TITLE
Gopro time update

### DIFF
--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -136,7 +136,7 @@ func ImportConnect(in, out string, sortOptions SortOptions) (*utils.Result, erro
 					end := sortOptions.DateRange[1]
                                         zoneName, _ := end.Zone()
                                         newTime := strings.Replace(tm.Format(time.UnixDate), "UTC", zoneName, -1)
-                                        tm, _ = time.Parse(time.UnixDate, new_time)
+                                        tm, _ = time.Parse(time.UnixDate, newTime)
 					mediaDate := tm.Format("02-01-2006")
 
 					if strings.Contains(sortOptions.DateFormat, "yyyy") && strings.Contains(sortOptions.DateFormat, "mm") && strings.Contains(sortOptions.DateFormat, "dd") {

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -134,8 +134,8 @@ func ImportConnect(in, out string, sortOptions SortOptions) (*utils.Result, erro
 					tm := time.Unix(i, 0).UTC()
 					start := sortOptions.DateRange[0]
 					end := sortOptions.DateRange[1]
-                                        zone_name, _ := end.Zone()
-                                        new_time := strings.Replace(tm.Format(time.UnixDate), "UTC", zone_name, -1)
+                                        zoneName, _ := end.Zone()
+                                        newTime := strings.Replace(tm.Format(time.UnixDate), "UTC", zoneName, -1)
                                         tm, _ = time.Parse(time.UnixDate, new_time)
 					mediaDate := tm.Format("02-01-2006")
 

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -131,15 +131,18 @@ func ImportConnect(in, out string, sortOptions SortOptions) (*utils.Result, erro
 					if err != nil {
 						continue
 					}
-					tm := time.Unix(i, 0)
+					tm := time.Unix(i, 0).UTC()
+					start := sortOptions.DateRange[0]
+					end := sortOptions.DateRange[1]
+                                        zone_name, _ := end.Zone()
+                                        new_time := strings.Replace(tm.Format(time.UnixDate), "UTC", zone_name, -1)
+                                        tm, _ = time.Parse(time.UnixDate, new_time)
 					mediaDate := tm.Format("02-01-2006")
 
 					if strings.Contains(sortOptions.DateFormat, "yyyy") && strings.Contains(sortOptions.DateFormat, "mm") && strings.Contains(sortOptions.DateFormat, "dd") {
 						mediaDate = tm.Format(replacer.Replace(sortOptions.DateFormat))
 					}
 
-					start := sortOptions.DateRange[0]
-					end := sortOptions.DateRange[1]
 					if tm.Before(start) {
 						continue
 					}


### PR DESCRIPTION
GoPro records the time in Unix format, and is when read in UTC format , is correct FOR THE LOCAL TIMEZONE.

This change reads the timestamp and replaces the time zone to local timezone, without altering the actual time.

