### PR TITLE
goReleaser only on tagging a release

### DIFF
--- a/.github/workflows/buidl.yaml
+++ b/.github/workflows/buidl.yaml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 name: Build Mac OS X/Linux
+on:
+  push:
+    tags:
+      - '*'
 jobs:
     build:
         name: GoReleaser build


### PR DESCRIPTION
Error is it is checking the commit against a tag, so propose to only run when you tag a release