### PR TITLE
fixes for using gopro connect with v1 cams

### DIFF
--- a/pkg/gopro/structs.go
+++ b/pkg/gopro/structs.go
@@ -105,7 +105,7 @@ type goProMediaList struct {
 			Mod  string        `json:"mod"`
 			Glrv string        `json:"glrv,omitempty"`
 			Ls   string        `json:"ls,omitempty"`
-			S    string        `json:"s"`
+			S    int64         `json:"s,string"`
 			G    string        `json:"g,omitempty"`
 			B    int           `json:"b,string,omitempty"`
 			L    int           `json:"l,string,omitempty"`
@@ -123,7 +123,7 @@ type ConnectDevice struct {
 
 type goProMediaMetadata struct {
 	Cre       string        `json:"cre"`
-	S         string        `json:"s"`
+	S         int64         `json:"s,string"`
 	Us        string        `json:"us"`
 	Mos       []interface{} `json:"mos"`
 	Eis       string        `json:"eis"`


### PR DESCRIPTION
# Fixes for GoPro Connect with v1 cams

<!--Replace the bracketed text ([xxx]) with your own!-->
<!--Tick the appropiate boxes!-->

Closes #49

- Use `gpMediaList`'s `s` parameter which indicates the file size instead of getting the value thru HTTP HEAD on cases: `Video`, `ChapteredVideo`, `Photo`. Using HTTP HEAD: `RawPhoto`, `MultiShot`
- Convert weird filename only on V2 and apply V1's chapter filenaming change
- Enable Turbo only on Turbo supported cams (H6..H8 are V2 but don't have gpTurbo)

FYI @daktak multi shots on H5S might still report `41 bytes` as HTTP HEAD response, no idea how to get around that one.

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass