### PR TITLE
Move SRT to specified folder and disable importing it completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Download from the releases tab, additionally, a github action will run for every
     -   `--buffersize`: Buffer size for copying files. Default is `1000 bytes`
     -   `--date`: Date format. Default is `dd-mm-yyyy`
     -   `--range`: Date range, for example: `12-03-2021,15-03-2021`
+    -   `skip_aux`: Skips `.THM`, `.LRV` files on GoPro cameras and .SRT files on DJI systems
+    -   `sort_by`: Sort by: `camera, location` (default: `camera, location` true)
     -   GoPro specific:
         -   `connection`: `sd_card`/`connect`
-        -   `skip_aux`: Skips `.THM`, `.LRV` files
-        -   `sort_by`: Sort by: `camera` (default: `camera` true)
 -   update - **updates your camera**
     -   `--input`: A directory pointing to your SD card, MTP or GoPro Connect not supported
     -   `--camera`: Type of device being updated. Values supported: `gopro, insta360`

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -49,25 +49,20 @@ var importCmd = &cobra.Command{
 			}
 
 			customCameraOpts := make(map[string]interface{})
+
+			skipAuxFiles := getFlagBool(cmd, "skip_aux", "true")
+			customCameraOpts["skip_aux"] = skipAuxFiles
+			sortBy := getFlagSlice(cmd, "sort_by")
+			if len(sortBy) == 0 {
+				customCameraOpts["sort_by"] = []string{"camera", "location"}
+			}
 			switch c {
 			case utils.GoPro:
-				skipAuxFiles := getFlagBool(cmd, "skip_aux", "true")
-				customCameraOpts["skip_aux"] = skipAuxFiles
-				sortBy := getFlagSlice(cmd, "sort_by")
-				if len(sortBy) == 0 {
-					customCameraOpts["sort_by"] = []string{"camera", "location"}
-				}
-
 				connection := getFlagString(cmd, "connection")
 				if connection == "" {
 					connection = "sd_card"
 				}
 				customCameraOpts["connection"] = connection
-			case utils.DJI, utils.Android:
-				sortBy := getFlagSlice(cmd, "sort_by")
-				if len(sortBy) == 0 {
-					customCameraOpts["sort_by"] = []string{"camera", "location"}
-				}
 			}
 			r, err := importFromCamera(c, input, filepath.Join(output, projectName), dateFormat, bufferSize, prefix, dateRange, customCameraOpts)
 			if err != nil {
@@ -110,10 +105,7 @@ func init() {
 	importCmd.Flags().StringSlice("range", []string{}, "A date range, eg: 01-05-2020,05-05-2020 -- also accepted: `today`, `yesterday`, `week`")
 	importCmd.Flags().StringP("connection", "x", "", "Connexion type: `sd_card`, `connect` (GoPro-specific)")
 	importCmd.Flags().StringSlice("sort_by", []string{}, "Sort files by: `camera`, `location`")
-
-	// GoPro-specific options
-
-	importCmd.Flags().StringP("skip_aux", "s", "", "GoPro: skip auxiliary files (THM, LRV)")
+	importCmd.Flags().StringP("skip_aux", "s", "true", "Skip auxiliary files (GoPro: THM, LRV. DJI: SRT)")
 }
 
 func importFromCamera(c utils.Camera, input string, output string, dateFormat string, bufferSize int, prefix string, dateRange []string, camOpts map[string]interface{}) (*utils.Result, error) {

--- a/pkg/dji/config.go
+++ b/pkg/dji/config.go
@@ -1,0 +1,15 @@
+package dji
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+const parent = "dji"
+
+func srtFolderFromConfig() string {
+	key := fmt.Sprintf("%s.srt", parent)
+	viper.SetDefault(key, "")
+	return viper.GetString(key)
+}

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -257,7 +257,11 @@ func Unzip(src string, dest string) error {
 func ParseCliOptions(cameraOptions map[string]interface{}) SortOptions {
 	byCamera := false
 	byLocation := false
-
+	skipAux := false
+	skipAuxOption, found := cameraOptions["skip_aux"]
+	if found {
+		skipAux = skipAuxOption.(bool)
+	}
 	sortByOptions, found := cameraOptions["sort_by"]
 	if found {
 		for _, sortop := range sortByOptions.([]string) {
@@ -271,8 +275,9 @@ func ParseCliOptions(cameraOptions map[string]interface{}) SortOptions {
 	}
 
 	return SortOptions{
-		ByCamera:   byCamera,
-		ByLocation: byLocation,
+		ByCamera:           byCamera,
+		ByLocation:         byLocation,
+		SkipAuxiliaryFiles: skipAux,
 	}
 }
 


### PR DESCRIPTION
# Set `skip_aux` to disable importing SRTs

<!--Replace the bracketed text ([xxx]) with your own!-->
<!--Tick the appropiate boxes!-->

Closes #58

- Move SRT files to `dji.srt` key value
- Allow GoPro's `skip_aux` to disable importing SRTs at all

### Type:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [ ] Insta360
- [X] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass