### PR TITLE
Use HiLight tags

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -55,6 +55,8 @@ var importCmd = &cobra.Command{
 			sortBy := getFlagSlice(cmd, "sort_by")
 			if len(sortBy) == 0 {
 				customCameraOpts["sort_by"] = []string{"camera", "location"}
+			} else {
+				customCameraOpts["sort_by"] = sortBy
 			}
 			switch c {
 			case utils.GoPro:
@@ -63,6 +65,8 @@ var importCmd = &cobra.Command{
 					connection = "sd_card"
 				}
 				customCameraOpts["connection"] = connection
+
+				customCameraOpts["tag_names"] = getFlagSlice(cmd, "tag_names")
 			}
 			r, err := importFromCamera(c, input, filepath.Join(output, projectName), dateFormat, bufferSize, prefix, dateRange, customCameraOpts)
 			if err != nil {
@@ -105,6 +109,7 @@ func init() {
 	importCmd.Flags().StringSlice("range", []string{}, "A date range, eg: 01-05-2020,05-05-2020 -- also accepted: `today`, `yesterday`, `week`")
 	importCmd.Flags().StringP("connection", "x", "", "Connexion type: `sd_card`, `connect` (GoPro-specific)")
 	importCmd.Flags().StringSlice("sort_by", []string{}, "Sort files by: `camera`, `location`")
+	importCmd.Flags().StringSlice("tag_names", []string{}, "Tag names for number of HiLight tags in last 10s of video, each position being the amount, eg: 'marked 1,good stuff,important' => num of tags: 1,2,3")
 	importCmd.Flags().StringP("skip_aux", "s", "true", "Skip auxiliary files (GoPro: THM, LRV. DJI: SRT)")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/konradit/mmt
 go 1.15
 
 require (
+	github.com/abema/go-mp4 v0.9.0
 	github.com/codingsince1985/geo-golang v1.8.3
 	github.com/dustin/go-humanize v1.0.0
 	github.com/erdaltsksn/cui v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/abema/go-mp4 v0.9.0 h1:WFkzn0J8uYTQ2MIWfgCaFHRB3VDkird5JncIjuuKjGI=
+github.com/abema/go-mp4 v0.9.0/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -213,6 +215,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -340,6 +343,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -449,6 +453,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e h1:s2RNOM/IGdY0Y6qfTeUKhDawdHDpK9RGBdx80qN4Ttw=
+github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e/go.mod h1:nBdnFKj15wFbf94Rwfq4m30eAcyY9V/IyKAGQFtqkW0=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -588,6 +594,7 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/sunfish-shogi/bufseekio v0.0.0-20210207115823-a4185644b365/go.mod h1:dEzdXgvImkQ3WLI+0KQpmEx8T/C/ma9KeS3AfmU899I=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -767,11 +774,13 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 h1:OK7RB6t2WQX54srQQYSXMW8dF5C6/8+oA/s5QBmmto4=
 golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -886,8 +895,9 @@ gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLv
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/src-d/go-billy.v4 v4.3.0/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
-gopkg.in/src-d/go-billy.v4 v4.3.1 h1:OkK1DmefDy1Z6Veu82wdNj/cLpYORhdX4qdaYCPwc7s=
 gopkg.in/src-d/go-billy.v4 v4.3.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
+gopkg.in/src-d/go-billy.v4 v4.3.2 h1:0SQA1pRztfTFx2miS8sA97XvooFeNOmvUenF4o0EcVg=
+gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOAJK+LsJg=
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.12.0 h1:CKgvBCJCcdfNnyXPYI4Cp8PaDDAmAPEN0CtfEdEAbd8=

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -42,7 +42,9 @@ func handleKill() {
 	}()
 }
 func caller(ip, path string, object interface{}) error {
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/%s", ip, path), nil)
 	if err != nil {
 		return err
@@ -243,18 +245,24 @@ func ImportConnect(in, out string, sortOptions utils.SortOptions) (*utils.Result
 							return
 						}
 
-						framerate := gpFileInfo.Fps / gpFileInfo.FpsDenom
+						importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, sortOptions.TagNames)
+
+						denom := gpFileInfo.FpsDenom
+						if denom == 0 {
+							denom = 1
+						}
+						framerate := gpFileInfo.Fps / denom
 						if framerate == 0 {
-							framerate = (gpFileInfo.FpsDenom / gpFileInfo.Fps)
+							framerate = (denom / gpFileInfo.Fps)
 						}
 
 						rfpsFolder := fmt.Sprintf("%sx%s %d", gpFileInfo.W, gpFileInfo.H, framerate)
 
-						forceGetFolder(filepath.Join(finalPath, "videos", rfpsFolder))
+						forceGetFolder(filepath.Join(finalPath, "videos", importanceName, rfpsFolder))
 
 						err = os.Rename(
 							filepath.Join(unsorted, origFilename),
-							filepath.Join(finalPath, "videos", rfpsFolder, filename),
+							filepath.Join(finalPath, "videos", importanceName, rfpsFolder, filename),
 						)
 						if err != nil {
 							inlineCounter.SetFailure(err, origFilename)

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -413,7 +413,15 @@ func importFromGoProV1(root string, output string, sortoptions utils.SortOptions
 						}
 						framerate := strings.ReplaceAll(s.Streams[0].RFrameRate, "/1", "")
 						rfpsFolder := fmt.Sprintf("%dx%d %s", s.Streams[0].Width, s.Streams[0].Height, framerate)
-						folder := filepath.Join(dayFolder, "videos", rfpsFolder)
+
+						additionalDir := ""
+						if hilights, err := getHiLights(osPathname); err == nil {
+							if durationResp, err := ffprobe.Duration(osPathname); err == nil {
+								additionalDir = filepath.Join(additionalDir, getImportanceName(hilights.Timestamps, int(durationResp.Streams[0].Duration), sortoptions.TagNames))
+							}
+						}
+
+						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
 							err := parse(folder, filename, osPathname, sortoptions, result, bar)
@@ -452,7 +460,15 @@ func importFromGoProV1(root string, output string, sortoptions utils.SortOptions
 						}
 						framerate := strings.ReplaceAll(s.Streams[0].RFrameRate, "/1", "")
 						rfpsFolder := fmt.Sprintf("%dx%d %s", s.Streams[0].Width, s.Streams[0].Height, framerate)
-						folder := filepath.Join(dayFolder, "videos", rfpsFolder)
+
+						additionalDir := ""
+						if hilights, err := getHiLights(osPathname); err == nil {
+							if durationResp, err := ffprobe.Duration(osPathname); err == nil {
+								additionalDir = filepath.Join(additionalDir, getImportanceName(hilights.Timestamps, int(durationResp.Streams[0].Duration), sortoptions.TagNames))
+							}
+						}
+
+						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
 							err := parse(folder, filename, osPathname, sortoptions, result, bar)

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -237,6 +237,12 @@ func importFromGoProV2(root string, output string, sortoptions utils.SortOptions
 						if !ftype.HeroMode {
 							additionalDir = "360"
 						}
+
+						if hilights, err := getHiLights(osPathname); err == nil {
+							if durationResp, err := ffprobe.Duration(osPathname); err == nil {
+								additionalDir = filepath.Join(additionalDir, getImportanceName(hilights.Timestamps, int(durationResp.Streams[0].Duration), sortoptions.TagNames))
+							}
+						}
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -117,6 +117,7 @@ func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange
 		BufferSize:         bufferSize,
 		Prefix:             prefix,
 		DateRange:          []time.Time{dateStart, dateEnd},
+		TagNames:           cameraOptions["tag_names"].([]string),
 	}
 
 	connectionType, found := cameraOptions["connection"]

--- a/pkg/gopro/hilight_tags.go
+++ b/pkg/gopro/hilight_tags.go
@@ -1,0 +1,27 @@
+package gopro
+
+import "time"
+
+func getImportanceName(tags []int, videoDuration int, names []string) string {
+	if videoDuration < 20 || len(names) < 3 {
+		return ""
+	}
+	var lastSeconds int = 10 // Last 10 seconds
+	rangeToFind := (videoDuration * int(time.Microsecond)) - lastSeconds*int(time.Microsecond)
+
+	howMany := 0
+	for _, tag := range tags {
+		if tag > rangeToFind {
+			howMany += 1
+		}
+	}
+
+	if howMany == 0 {
+		return ""
+	}
+
+	if howMany > len(names) {
+		howMany = len(names)
+	}
+	return names[howMany-1]
+}

--- a/pkg/gopro/hilight_tags.go
+++ b/pkg/gopro/hilight_tags.go
@@ -6,13 +6,13 @@ func getImportanceName(tags []int, videoDuration int, names []string) string {
 	if videoDuration < 20 || len(names) < 3 {
 		return ""
 	}
-	var lastSeconds int = 10 // Last 10 seconds
+	var lastSeconds = 10 // Last 10 seconds
 	rangeToFind := (videoDuration * int(time.Microsecond)) - lastSeconds*int(time.Microsecond)
 
 	howMany := 0
 	for _, tag := range tags {
 		if tag > rangeToFind {
-			howMany += 1
+			howMany++
 		}
 	}
 

--- a/pkg/gopro/hilight_tags_test.go
+++ b/pkg/gopro/hilight_tags_test.go
@@ -1,0 +1,60 @@
+package gopro
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var importanceNames = []string{"Marked 1", "Lit AF", "Important"}
+
+func TestLengthTooShort(t *testing.T) {
+	payload := `{"cre":"1672490791","s":"56337675","us":"0","mos":[],"eis":"0","pta":"1","ao":"stereo","tr":"0","mp":"0","gumi":"edc695738198c0e25b5d439c036dbfd1","ls":"4149813","cl":"0","hc":"3","hi":[1360,3400,7400],"dur":"10","w":"1920","h":"1080","fps":"3600","fps_denom":"90000","prog":"1","subsample":"0"}`
+	gpFileInfo := goProMediaMetadata{}
+	err := json.Unmarshal([]byte(payload), &gpFileInfo)
+	require.NoError(t, err)
+
+	importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, importanceNames)
+	require.Empty(t, importanceName)
+}
+
+func TestAllInBounds(t *testing.T) {
+	payload := `{"cre":"1672494840","s":"116068980","us":"0","mos":[],"eis":"0","pta":"1","ao":"stereo","tr":"0","mp":"0","gumi":"d3d262f1e7c4772ef00281333e482074","ls":"9323550","cl":"0","hc":"2","hi":[18880,20440],"dur":"24","w":"1920","h":"1080","fps":"3600","fps_denom":"90000","prog":"1","subsample":"0"}`
+	gpFileInfo := goProMediaMetadata{}
+	err := json.Unmarshal([]byte(payload), &gpFileInfo)
+	require.NoError(t, err)
+
+	importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, importanceNames)
+	require.Equal(t, importanceName, "Lit AF")
+}
+
+func TestMarkerOverflow(t *testing.T) {
+	payload := `{"cre":"1672496212","s":"127341393","us":"0","mos":[],"eis":"0","pta":"1","ao":"stereo","tr":"0","mp":"0","gumi":"2de66cc9ef62b52c326b20b7ad15c098","ls":"11858166","cl":"0","hc":"4","hi":[22600,24320,25920,27640],"dur":"30","w":"1920","h":"1080","fps":"3600","fps_denom":"90000","prog":"1","subsample":"0"}`
+	gpFileInfo := goProMediaMetadata{}
+	err := json.Unmarshal([]byte(payload), &gpFileInfo)
+	require.NoError(t, err)
+
+	importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, importanceNames)
+	require.Equal(t, importanceName, "Important")
+}
+
+func TestOneMarker(t *testing.T) {
+	payload := `{"cre":"1672496247","s":"171050196","us":"0","mos":[],"eis":"0","pta":"1","ao":"stereo","tr":"0","mp":"0","gumi":"1ff6fdfbc8c3dbe6ca064bb00283e7c0","ls":"17821498","cl":"0","hc":"1","hi":[42720],"dur":"46","w":"1920","h":"1080","fps":"3600","fps_denom":"90000","prog":"1","subsample":"0"}`
+	gpFileInfo := goProMediaMetadata{}
+	err := json.Unmarshal([]byte(payload), &gpFileInfo)
+	require.NoError(t, err)
+
+	importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, importanceNames)
+	require.Equal(t, importanceName, "Marked 1")
+}
+
+func TestNoneAtAll(t *testing.T) {
+	payload := `{"cre":"1672497199","s":"301389825","us":"0","mos":[],"eis":"0","pta":"1","ao":"stereo","tr":"0","mp":"0","gumi":"012912787a0bdffaab89f940285de16c","ls":"31581398","cl":"0","hc":"0","hi":[],"dur":"80","w":"1920","h":"1080","fps":"3600","fps_denom":"90000","prog":"1","subsample":"0"}`
+	gpFileInfo := goProMediaMetadata{}
+	err := json.Unmarshal([]byte(payload), &gpFileInfo)
+	require.NoError(t, err)
+
+	importanceName := getImportanceName(gpFileInfo.Hi, gpFileInfo.Dur, importanceNames)
+	require.Empty(t, importanceName)
+}

--- a/pkg/gopro/mp4parse.go
+++ b/pkg/gopro/mp4parse.go
@@ -1,0 +1,61 @@
+package gopro
+
+import (
+	"errors"
+	"os"
+
+	"github.com/abema/go-mp4"
+)
+
+type HiLights struct {
+	Count      int
+	Timestamps []int
+}
+
+func BoxTypeHMMT() mp4.BoxType { return mp4.StrToBoxType("HMMT") }
+
+type HMMT struct {
+	mp4.Box
+	Count   int   `mp4:"0,size=32,len=dynamic,int"`
+	Entries []int `mp4:"1,size=32,len=dynamic,int"`
+}
+
+func (*HMMT) GetType() mp4.BoxType {
+	return BoxTypeHMMT()
+}
+
+func (h *HMMT) GetFieldLength(name string, ctx mp4.Context) uint {
+	return uint(h.Count)
+}
+
+func getHiLights(path string) (*HiLights, error) {
+	mp4.AddBoxDef(&HMMT{}, 0)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	hmmtData := &HMMT{}
+
+	_, _ = mp4.ReadBoxStructure(f, func(h *mp4.ReadHandle) (interface{}, error) {
+		if h.BoxInfo.IsSupportedType() && h.BoxInfo.Type.String() == "moov" || h.BoxInfo.Type.String() == "udta" || h.BoxInfo.Type.String() == "HMMT" {
+			box, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			if h.BoxInfo.Type.String() == "HMMT" {
+				hmmtData = box.(*HMMT)
+			}
+			return h.Expand()
+		}
+		return nil, nil
+	})
+
+	if hmmtData != nil {
+		return &HiLights{
+			hmmtData.Count,
+			hmmtData.Entries}, nil
+	}
+	return nil, errors.New("No data found")
+}

--- a/pkg/gopro/structs.go
+++ b/pkg/gopro/structs.go
@@ -134,8 +134,8 @@ type goProMediaMetadata struct {
 	Ls        string        `json:"ls"`
 	Cl        string        `json:"cl"`
 	Hc        string        `json:"hc"`
-	Hi        []interface{} `json:"hi"`
-	Dur       string        `json:"dur"`
+	Hi        []int         `json:"hi"`
+	Dur       int           `json:"dur,string"`
 	W         string        `json:"w"`
 	H         string        `json:"h"`
 	Fps       int           `json:"fps,string"`

--- a/pkg/utils/ffprobe.go
+++ b/pkg/utils/ffprobe.go
@@ -35,6 +35,13 @@ type FramesResponse struct {
 	} `json:"streams"`
 }
 
+type DurationResponse struct {
+	Programs []interface{} `json:"programs"`
+	Streams  []struct {
+		Duration float32 `json:"duration,string"`
+	} `json:"streams"`
+}
+
 type GPSLocation struct {
 	Format struct {
 		Tags struct {
@@ -116,6 +123,19 @@ func (f *FFprobe) VideoSize(path string) (*VideoSizeResponse, error) {
 func (f *FFprobe) Frames(path string) (*FramesResponse, error) {
 	result := FramesResponse{}
 	out, err := f.executeGetInfo(path, "nb_frames")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(out, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (f *FFprobe) Duration(path string) (*DurationResponse, error) {
+	result := DurationResponse{}
+	out, err := f.executeGetInfo(path, "duration")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/ordering.go
+++ b/pkg/utils/ordering.go
@@ -18,6 +18,7 @@ type SortOptions struct {
 	BufferSize         int
 	Prefix             string
 	DateRange          []time.Time
+	TagNames           []string
 }
 
 func GetOrder(sortoptions SortOptions, GetLocation locationUtil, osPathname, out, mediaDate, deviceName string) string {


### PR DESCRIPTION
# Use HiLight tags

Closes #13

- [X] Use HiLight tags via GoPro HTTP API for sorting videos
- [X] Get HiLight tags count via GPMF (HERO6 and newer) (Unable to get from GPMF stream, but MOOV>UDTA>HMMT box works fine on H11)
- [X] Get HiLight tags count via HMMT in UDTA box (HERO5 and lower)

### Type:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass