### PR TITLE
Add helper flags for detecting cameras

### DIFF
--- a/cmd/list_devices.go
+++ b/cmd/list_devices.go
@@ -6,6 +6,7 @@ import (
 	"github.com/erdaltsksn/cui"
 	"github.com/fatih/color"
 	"github.com/konradit/mmt/pkg/gopro"
+	"github.com/konradit/mmt/pkg/utils"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/spf13/cobra"
 )
@@ -19,8 +20,8 @@ var listDevicesCmd = &cobra.Command{
 		if len(partitions) >= 1 {
 			color.Yellow("📷 Devices:")
 		}
-		for i, partition := range partitions {
-			color.Cyan(fmt.Sprintf("\t🎥 %v - %v (%v)\n", i, partition.Device, partition.Mountpoint))
+		for _, partition := range partitions {
+			color.Cyan(fmt.Sprintf("\t🎥 %v (%v)\n", partition.Device, utils.CameraGuess(partition.Device)))
 		}
 
 		networkDevices, err := gopro.GetGoProNetworkAddresses()

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -43,7 +43,7 @@ func handleKill() {
 }
 func caller(ip, path string, object interface{}) error {
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/%s", ip, path), nil)
 	if err != nil {
@@ -199,10 +199,7 @@ func ImportConnect(in, out string, sortOptions utils.SortOptions) (*utils.Result
 					mediaDate = tm.Format(replacer.Replace(sortOptions.DateFormat))
 				}
 
-				if tm.Before(start) {
-					continue
-				}
-				if tm.After(end) {
+				if tm.Before(start) || tm.After(end) {
 					continue
 				}
 

--- a/pkg/gopro/detect.go
+++ b/pkg/gopro/detect.go
@@ -1,0 +1,30 @@
+package gopro
+
+import (
+	mErrors "github.com/konradit/mmt/pkg/errors"
+	"github.com/konradit/mmt/pkg/utils"
+	"github.com/shirou/gopsutil/disk"
+)
+
+func Detect() (string, utils.ConnectionType, error) {
+	partitions, err := disk.Partitions(false)
+	if err != nil {
+		return "", "", err
+	}
+	for _, partition := range partitions {
+		if utils.CameraGuess(partition.Device) == utils.GoPro.ToString() {
+			return partition.Device, utils.SDCard, nil
+		}
+	}
+
+	networkDevices, err := GetGoProNetworkAddresses()
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(networkDevices) > 0 {
+		return networkDevices[0].IP, utils.Connect, nil
+	}
+
+	return "", "", mErrors.ErrNoCameraDetected
+}

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -134,7 +134,12 @@ func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange
 		}
 	}
 
-	gpVersion, err := readInfo(in)
+	versionContent, err := os.ReadFile(filepath.Join(in, "MISC", fmt.Sprint(Version)))
+	if err != nil {
+		return nil, err
+	}
+
+	gpVersion, err := readInfo(versionContent)
 	if err != nil {
 		return nil, err
 	}
@@ -586,20 +591,11 @@ func cleanVersion(s string) string {
 	return excludingLast
 }
 
-func readInfo(in string) (*Info, error) {
-	jsonFile, err := os.Open(filepath.Join(in, "MISC", fmt.Sprint(Version)))
-	if err != nil {
-		return nil, err
-	}
-	defer jsonFile.Close()
-	inBytes, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		return nil, err
-	}
+func readInfo(inBytes []byte) (*Info, error) {
 	text := string(inBytes)
 	clean := cleanVersion(text)
 	var gpVersion Info
-	err = json.Unmarshal([]byte(clean), &gpVersion)
+	err := json.Unmarshal([]byte(clean), &gpVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -84,6 +84,8 @@ func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange
 			dateStart = today.Add(-24 * time.Hour)
 		case "week":
 			dateStart = today.Add(-24 * time.Duration((int(dateEnd.Weekday()) - 1)) * time.Hour)
+		case "week-back":
+			dateStart = today.Add((-24 * 7) * time.Hour)
 		}
 	}
 

--- a/pkg/gopro/gopro_test.go
+++ b/pkg/gopro/gopro_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestCameraInfoParse(t *testing.T) {
-
 	fileContents := `{
 		"info version":"2.0"
 		,"firmware version":"H22.01.02.01.00"
@@ -39,5 +38,4 @@ func TestCameraInfoParse(t *testing.T) {
 	require.Equal(t, "H22.01.02.01.00", gpVersion.FirmwareVersion)
 	require.Equal(t, "24000000000", gpVersion.WifiMac)
 	require.Equal(t, "2.0", gpVersion.InfoVersion)
-
 }

--- a/pkg/gopro/gopro_test.go
+++ b/pkg/gopro/gopro_test.go
@@ -1,0 +1,43 @@
+package gopro
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCameraInfoParse(t *testing.T) {
+
+	fileContents := `{
+		"info version":"2.0"
+		,"firmware version":"H22.01.02.01.00"
+		,"wifi mac":"24000000000"
+		,"camera type":"HERO11 Black"
+		,"camera serial number":"C3471000000000"
+		}
+		`
+	gopro := fstest.MapFS{
+		"MISC/version.txt": {
+			Data: []byte(fileContents),
+		},
+		"MISC\\version.txt": {
+			Data: []byte(fileContents),
+		},
+	}
+
+	versionContent, err := gopro.ReadFile(filepath.Join(".", "MISC", fmt.Sprint(Version)))
+	require.NoError(t, err)
+
+	gpVersion, err := readInfo(versionContent)
+	require.NoError(t, err)
+
+	require.Equal(t, "C3471000000000", gpVersion.CameraSerialNumber)
+	require.Equal(t, "HERO11 Black", gpVersion.CameraType)
+	require.Equal(t, "H22.01.02.01.00", gpVersion.FirmwareVersion)
+	require.Equal(t, "24000000000", gpVersion.WifiMac)
+	require.Equal(t, "2.0", gpVersion.InfoVersion)
+
+}

--- a/pkg/gopro/update.go
+++ b/pkg/gopro/update.go
@@ -32,7 +32,13 @@ func UpdateCamera(sdcard string) error {
 	if err != nil {
 		return err
 	}
-	gpVersion, err := readInfo(sdcard)
+
+	versionContent, err := os.ReadFile(filepath.Join(sdcard, "MISC", fmt.Sprint(Version)))
+	if err != nil {
+		return err
+	}
+
+	gpVersion, err := readInfo(versionContent)
 	if err != nil {
 		return err
 	}

--- a/pkg/insta360/detect.go
+++ b/pkg/insta360/detect.go
@@ -1,0 +1,20 @@
+package insta360
+
+import (
+	mErrors "github.com/konradit/mmt/pkg/errors"
+	"github.com/konradit/mmt/pkg/utils"
+	"github.com/shirou/gopsutil/disk"
+)
+
+func Detect() (string, utils.ConnectionType, error) {
+	partitions, err := disk.Partitions(false)
+	if err != nil {
+		return "", "", err
+	}
+	for _, partition := range partitions {
+		if utils.CameraGuess(partition.Device) == utils.Insta360.ToString() {
+			return partition.Device, utils.SDCard, nil
+		}
+	}
+	return "", "", mErrors.ErrNoCameraDetected
+}

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -27,7 +27,7 @@ const (
 	Android
 )
 
-func (c Camera) toString() string {
+func (c Camera) ToString() string {
 	extensions := [...]string{"gopro", "dji", "insta360", "android"}
 
 	return extensions[c]
@@ -35,17 +35,30 @@ func (c Camera) toString() string {
 
 func CameraGet(s string) (Camera, error) {
 	switch s {
-	case GoPro.toString():
+	case GoPro.ToString():
 		return GoPro, nil
-	case DJI.toString():
+	case DJI.ToString():
 		return DJI, nil
-	case Insta360.toString():
+	case Insta360.ToString():
 		return Insta360, nil
-	case Android.toString():
+	case Android.ToString():
 		return Android, nil
 	default:
 		return 10, mErrors.ErrUnsupportedCamera(s)
 	}
+}
+
+func CameraGuess(input string) string {
+	_, err := os.Stat(filepath.Join(input, "MISC", "version.txt"))
+	if err == nil {
+		return GoPro.ToString()
+	}
+
+	_, err = os.Stat(filepath.Join(input, "DCIM", "fileinfo_list.list"))
+	if err == nil {
+		return Insta360.ToString()
+	}
+	return ""
 }
 
 type Result struct {


### PR DESCRIPTION
# Add helper flags for detecting cameras

Closes #12

- `--use_gopro` and `--use_insta360` will detect any plugged in camera and use it

### Type:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [X] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


