### PR TITLE
ffmpeg fix merge

### DIFF
--- a/pkg/videomanipulation/ffmpeg.go
+++ b/pkg/videomanipulation/ffmpeg.go
@@ -117,7 +117,7 @@ func (v *VMan) merge(output string, bar *mpb.Bar, ffConfig FFConfig, videos ...s
 
 func (v *VMan) Merge(bar *mpb.Bar, videos ...string) error {
 	mergeConfig := v.NewDefaultConfig()
-	mergeConfig.InArgs = append(mergeConfig.InArgs, []string{"-f", "concat", "-safe", "0"}...)
+	mergeConfig.InArgs = append(mergeConfig.InArgs, []string{"-f", "concat", "-safe", "0", "-ignore_unknown"}...)
 	mergeConfig.OutArgs = append(mergeConfig.OutArgs, []string{"-map", "0:0", "-map", "0:1", "-map", "0:3"}...)
 
 	err := v.merge(getMergedOutputFilename(videos[0]), bar, mergeConfig, videos...)


### PR DESCRIPTION
# Fix FFMPEG Merge

Cannot map stream #0:3 - unsupported type.

<!--Replace the bracketed text ([xxx]) with your own!-->
<!--Tick the appropiate boxes!-->

Added -ignore_unknown to allow concat to merge files

```
$ mmt merge --input GOPR1544.MP4 GOPR1543.MP4
Using config file: /home/user/.mmt.yaml
🐈GOPR1544.MP4 0 % [----------------------------------------------------------] 0s
2023/01/09 11:42:31 Failed Finish FFMPEG ([-y -f concat -safe 0 -hwaccel cuda -i ./filelist.1205182968.txt -c:v copy -c:a copy -map 0:0 -map 0:1 -map 0:3 -hls_list_size 0 GOPR1544-merged.MP4]) with exit status 1 message
```
```
[concat @ 0x603cf33e9a40] Could not find codec parameters for stream 3 (Unknown: none): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, concat, from './filelist.1298481168.txt':
  Duration: N/A, start: 0.000000, bitrate: 60100 kb/s
  Stream #0:0(eng): Video: h264 (High) (avc1 / 0x31637661), yuvj420p(pc, bt709, progressive), 2704x1520 [SAR 1:1 DAR 169:95], 59938 kb/s, 47.95 fps, 47.95 tbr, 48k tbn
    Metadata:
      creation_time   : 2023-01-07T07:44:41.000000Z
      handler_name    :         GoPro AVC
      vendor_id       : [0][0][0][0]
      encoder         : GoPro AVC encoder
  Stream #0:1(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s
    Metadata:
      creation_time   : 2023-01-07T07:44:41.000000Z
      handler_name    :         GoPro AAC
      vendor_id       : [0][0][0][0]
  Stream #0:2(eng): Data: bin_data (gpmd / 0x646D7067), 33 kb/s
    Metadata:
      creation_time   : 2023-01-07T07:44:41.000000Z
      handler_name    :         GoPro MET
  Stream #0:3: Unknown: none
Cannot map stream #0:3 - unsupported type.
If you want unsupported types ignored instead of failing, please use the -ignore_unknown option
If you want them copied, please use -copy_unknown
```
```
$ ffmpeg -version
ffmpeg version 5.0.2 Copyright (c) 2000-2022 the FFmpeg developers
built with gcc 12 (GCC)
configuration: --prefix=/usr --bindir=/usr/bin --datadir=/usr/share/ffmpeg --docdir=/usr/share/doc/ffmpeg --incdir=/usr/include/ffmpeg --libdir=/usr/lib64 --mandir=/usr/share/man --arch=x86_64 --optflags='-O2 -flto=auto -ffat-lto-objects
 -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobi
n-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection' --extra-ldflags='-Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-ann
obin-cc1 -Wl,--build-id=sha1 ' --extra-cflags=' -I/usr/include/rav1e' --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-version3 --enable-bzlib --enable-chromaprint --disable-crystalhd --enable-fontco
nfig --enable-frei0r --enable-gcrypt --enable-gnutls --enable-ladspa --enable-libaom --enable-libdav1d --enable-libass --enable-libbluray --enable-libbs2b --enable-libcdio --enable-libdrm --enable-libjack --enable-libfreetype --enable-li
bfribidi --enable-libgsm --enable-libilbc --enable-libmp3lame --enable-libmysofa --enable-nvenc --enable-openal --enable-opencl --enable-opengl --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg 
--enable-librav1e --enable-librubberband --enable-libsmbclient --enable-version3 --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libtwolame --enable-lib
vorbis --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-version3 --enable-vapoursynth --enable-libvpx --enable-vulkan --enable-libglslang --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libxml2 
--enable-libzimg --enable-libzmq --enable-libzvbi --enable-lv2 --enable-avfilter --enable-libmodplug --enable-postproc --enable-pthreads --disable-static --enable-shared --enable-gpl --disable-debug --disable-stripping --shlibdir=/usr/li
b64 --enable-lto --enable-libmfx --enable-runtime-cpudetect
libavutil      57. 17.100 / 57. 17.100
libavcodec     59. 18.100 / 59. 18.100
libavformat    59. 16.100 / 59. 16.100
libavdevice    59.  4.100 / 59.  4.100
libavfilter     8. 24.100 /  8. 24.100
libswscale      6.  4.100 /  6.  4.100
libswresample   4.  3.100 /  4.  3.100
libpostproc    56.  3.100 / 56.  3.100

```

### Type:

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ x] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [ ] Import
- [ x] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


