### PR TITLE
Allow overriding camera name via CLI

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -41,6 +41,7 @@ var importCmd = &cobra.Command{
 		bufferSize := getFlagInt(cmd, "buffer", "1000")
 		prefix := getFlagString(cmd, "prefix")
 		dateRange := getFlagSlice(cmd, "range")
+		cameraName := getFlagString(cmd, "camera_name")
 
 		customCameraOpts := make(map[string]interface{})
 
@@ -87,7 +88,7 @@ var importCmd = &cobra.Command{
 				}
 				customCameraOpts["tag_names"] = getFlagSlice(cmd, "tag_names")
 			}
-			r, err := importFromCamera(c, input, filepath.Join(output, projectName), dateFormat, bufferSize, prefix, dateRange, customCameraOpts)
+			r, err := importFromCamera(c, input, filepath.Join(output, projectName), dateFormat, bufferSize, prefix, dateRange, cameraName, customCameraOpts)
 			if err != nil {
 				cui.Error("Something went wrong", err)
 			}
@@ -130,22 +131,23 @@ func init() {
 	importCmd.Flags().StringSlice("sort_by", []string{}, "Sort files by: `camera`, `location`")
 	importCmd.Flags().StringSlice("tag_names", []string{}, "Tag names for number of HiLight tags in last 10s of video, each position being the amount, eg: 'marked 1,good stuff,important' => num of tags: 1,2,3")
 	importCmd.Flags().StringP("skip_aux", "s", "true", "Skip auxiliary files (GoPro: THM, LRV. DJI: SRT)")
+	importCmd.Flags().String("camera_name", "", "Override camera name detection with specified string")
 
 	// Camera helpers
 	importCmd.Flags().Bool("use_gopro", false, "Detect GoPro camera attached")
 	importCmd.Flags().Bool("use_insta360", false, "Detect Insta360 camera attached")
 }
 
-func importFromCamera(c utils.Camera, input string, output string, dateFormat string, bufferSize int, prefix string, dateRange []string, camOpts map[string]interface{}) (*utils.Result, error) {
+func importFromCamera(c utils.Camera, input string, output string, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraName string, camOpts map[string]interface{}) (*utils.Result, error) {
 	switch c {
 	case utils.GoPro:
-		return gopro.Import(input, output, dateFormat, bufferSize, prefix, dateRange, camOpts)
+		return gopro.Import(input, output, dateFormat, bufferSize, prefix, dateRange, cameraName, camOpts)
 	case utils.DJI:
-		return dji.Import(input, output, dateFormat, bufferSize, prefix, dateRange, camOpts)
+		return dji.Import(input, output, dateFormat, bufferSize, prefix, dateRange, cameraName, camOpts)
 	case utils.Insta360:
-		return insta360.Import(input, output, dateFormat, bufferSize, prefix, dateRange, camOpts)
+		return insta360.Import(input, output, dateFormat, bufferSize, prefix, dateRange, cameraName, camOpts)
 	case utils.Android:
-		return android.Import(input, output, dateFormat, bufferSize, prefix, dateRange, camOpts)
+		return android.Import(input, output, dateFormat, bufferSize, prefix, dateRange, cameraName, camOpts)
 	}
 	return nil, mErrors.ErrUnsupportedCamera("")
 }

--- a/pkg/android/android.go
+++ b/pkg/android/android.go
@@ -59,7 +59,7 @@ func prepare(out string, deviceFileName string, deviceModel string, mediaDate st
 	}
 	return bar, dayFolder, nil
 }
-func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraOptions map[string]interface{}) (*utils.Result, error) {
+func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraName string, cameraOptions map[string]interface{}) (*utils.Result, error) {
 	var result utils.Result
 
 	sortOptions := utils.ParseCliOptions(cameraOptions)

--- a/pkg/dji/dji.go
+++ b/pkg/dji/dji.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/djherbis/times.v1"
 )
 
-func getDeviceNameFromPhoto(path string) (string, error) {
+func getDeviceNameFromPhoto(path string) (string, error) { //nolint:unused
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -54,7 +54,7 @@ func getRfpsFolder(pathName string) (string, error) {
 	fpsAsFloat := strconv.Itoa(framerate.(int))
 	return fmt.Sprintf("%dx%d %s", s.Streams[0].Width, s.Streams[0].Height, fpsAsFloat), nil
 }
-func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraOptions map[string]interface{}) (*utils.Result, error) {
+func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraName string, cameraOptions map[string]interface{}) (*utils.Result, error) {
 	/* Import method using SD card bay or SD card reader */
 
 	dateStart := time.Date(0000, time.Month(1), 1, 0, 0, 0, 0, time.UTC)
@@ -166,12 +166,15 @@ func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange
 
 	root := strings.Split(gpVersion.FirmwareVersion, ".")[0]
 
+	if cameraName == "" {
+		cameraName = gpVersion.CameraType
+	}
 	switch root {
 	case "HD6", "HD7", "HD8", "H19", "HD9", "H21", "H22":
-		result := importFromGoProV2(filepath.Join(in, fmt.Sprint(DCIM)), out, sortOptions, gpVersion.CameraType)
+		result := importFromGoProV2(filepath.Join(in, fmt.Sprint(DCIM)), out, sortOptions, cameraName)
 		return &result, nil
 	case "HD2", "HD3", "HD4", "HX", "HD5":
-		result := importFromGoProV1(filepath.Join(in, fmt.Sprint(DCIM)), out, sortOptions, gpVersion.CameraType)
+		result := importFromGoProV1(filepath.Join(in, fmt.Sprint(DCIM)), out, sortOptions, cameraName)
 		return &result, nil
 	default:
 		return nil, mErrors.ErrUnsupportedCamera(gpVersion.CameraType)

--- a/pkg/insta360/insta360.go
+++ b/pkg/insta360/insta360.go
@@ -40,9 +40,12 @@ func getDeviceName(manifest string) string {
 	}
 	return fmt.Sprintf("Insta360%s", modelName[0])
 }
-func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraOptions map[string]interface{}) (*utils.Result, error) {
+func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange []string, cameraName string, cameraOptions map[string]interface{}) (*utils.Result, error) {
 	sortOptions := utils.ParseCliOptions(cameraOptions)
 
+	if cameraName == "" {
+		cameraName = getDeviceName(filepath.Join(in, "DCIM", "fileinfo_list.list"))
+	}
 	di, err := disk.GetInfo(in)
 	if err != nil {
 		return nil, err
@@ -146,7 +149,7 @@ func Import(in, out, dateFormat string, bufferSize int, prefix string, dateRange
 
 					wg.Add(1)
 					bar := utils.GetNewBar(progressBar, int64(info.Size()), de.Name(), utils.IoTX)
-					dayFolder := utils.GetOrder(sortOptions, nil, osPathname, out, mediaDate, getDeviceName(filepath.Join(in, "DCIM", "fileinfo_list.list")))
+					dayFolder := utils.GetOrder(sortOptions, nil, osPathname, out, mediaDate, cameraName)
 
 					x := de.Name()
 

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -310,7 +310,6 @@ func FindFolderInPath(entirePath, directory string) (string, error) {
 
 type ResultCounter struct {
 	mu               sync.Mutex
-	CameraName       string
 	Errors           []error
 	FilesNotImported []string
 	FilesImported    int
@@ -321,18 +320,6 @@ func (rc *ResultCounter) SetFailure(err error, file string) {
 	rc.Errors = append(rc.Errors, err)
 	rc.FilesNotImported = append(rc.FilesNotImported, file)
 	rc.mu.Unlock()
-}
-
-func (rc *ResultCounter) SetCameraName(camName string) {
-	rc.mu.Lock()
-	rc.CameraName = camName
-	rc.mu.Unlock()
-}
-
-func (rc *ResultCounter) GetCameraName() string {
-	rc.mu.Lock()
-	defer rc.mu.Unlock()
-	return rc.CameraName
 }
 
 func (rc *ResultCounter) SetSuccess() {

--- a/pkg/utils/ordering.go
+++ b/pkg/utils/ordering.go
@@ -46,6 +46,9 @@ func GetOrder(sortoptions SortOptions, GetLocation locationUtil, osPathname, out
 				reverseLocation, reverseerr := ReverseLocation(*locationFromFile)
 				if reverseerr == nil {
 					location = reverseLocation
+					if location == "" || location == " " {
+						location = fallbackFromConfig()
+					}
 				}
 			}
 			if sortoptions.ByLocation {


### PR DESCRIPTION
# Allow overriding camera name via CLI

<!--Replace the bracketed text ([xxx]) with your own!-->
<!--Tick the appropiate boxes!-->

Helpful for Insta360 / DJI ordering where getting the name can fail

### Type:

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [X] Insta360
- [X] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


