### PR TITLE
use better gps measurement for videos

### DIFF
--- a/pkg/gopro/location.go
+++ b/pkg/gopro/location.go
@@ -62,7 +62,7 @@ func fromMP4(videoPath string) (*utils.Location, error) {
 
 		telems := lastEvent.ShitJson()
 		for _, telem := range telems {
-			if telem.Latitude == 0 || telem.Longitude == 0 || telem.GpsAccuracy > gpsMinAccuracyFromConfig() || !slices.Contains(gpsLockTypesFromConfig(), int(telem.GpsFix)) {
+			if telem.Speed == 0 || telem.Latitude == 0 || telem.Longitude == 0 || telem.GpsAccuracy > gpsMinAccuracyFromConfig() || !slices.Contains(gpsLockTypesFromConfig(), int(telem.GpsFix)) {
 				continue
 			}
 			return &utils.Location{


### PR DESCRIPTION
It has happened to me in many videos that the first GPS measurements result in incorrect locations, I have analyzed the tags and seen that when the speed is 0 it is not a correct GPS value

I get the data with exiftool -ee video.mp4

example:

<pre>
.
.
.
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:35.100
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 0 deg 0' 0.00" N
GPS Longitude                   : 0 deg 0' 0.00" E
GPS Altitude                    : -17 m
GPS Speed                       : 0
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:35.300
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 19 deg 32' 54.09" N
GPS Longitude                   : 12 deg 56' 8.08" W
GPS Altitude                    : 3369.107 m
GPS Speed                       : 0
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:35.400
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 32 deg 11' 3.69" N
GPS Longitude                   : 14 deg 28' 14.32" W
GPS Altitude                    : 3977.121 m
GPS Speed                       : 0.008
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.400
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 721.89 m
GPS Speed                       : 0.011
GPS Speed 3D                    : 0.02
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.500
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.055 m
GPS Speed                       : 0.014
GPS Speed 3D                    : 0.01
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.700
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.004 m
GPS Speed                       : 0.013
GPS Speed 3D                    : 0.01
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.800
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.193 m
GPS Speed                       : 0.031
GPS Speed 3D                    : 0.03
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:39.800
GPS Horizontal Positioning Error: 1.62
GPS Latitude                    : 40 deg 46' 8.77" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.134 m
GPS Speed                       : 0.022
GPS Speed 3D                    : 0.02
.
.
.
.
</pre>



but with the timelapse videos that there is little speed, below 0 it does not locate the video
It looks like a problem with the gopro-utils/telemetry library, but I don't get that far in Go

Example:

<pre>
.
.
.
.
GPS Date Time                   : 2023:02:18 13:39:35.100
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 0 deg 0' 0.00" N
GPS Longitude                   : 0 deg 0' 0.00" E
GPS Altitude                    : -17 m
GPS Speed                       : 0
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:35.300
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 19 deg 32' 54.09" N
GPS Longitude                   : 12 deg 56' 8.08" W
GPS Altitude                    : 3369.107 m
GPS Speed                       : 0
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:35.400
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 32 deg 11' 3.69" N
GPS Longitude                   : 14 deg 28' 14.32" W
GPS Altitude                    : 3977.121 m
GPS Speed                       : 0.008
GPS Speed 3D                    : 0
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.400
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 721.89 m
GPS Speed                       : 0.011
GPS Speed 3D                    : 0.02
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.500
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.055 m
GPS Speed                       : 0.014
GPS Speed 3D                    : 0.01
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.700
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.004 m
GPS Speed                       : 0.013
GPS Speed 3D                    : 0.01
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:37.800
GPS Horizontal Positioning Error: 1.64
GPS Latitude                    : 40 deg 46' 8.78" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.193 m
GPS Speed                       : 0.031
GPS Speed 3D                    : 0.03
GPS Measure Mode                : 3-Dimensional Measurement
GPS Date Time                   : 2023:02:18 13:39:39.800
GPS Horizontal Positioning Error: 1.62
GPS Latitude                    : 40 deg 46' 8.77" N
GPS Longitude                   : 0 deg 19' 44.77" E
GPS Altitude                    : 722.134 m
GPS Speed                       : 0.022
GPS Speed 3D                    : 0.02
.
.
.
.
</pre>

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [ ] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


