### PR TITLE
Only check date range when defined

### DIFF
--- a/pkg/android/android.go
+++ b/pkg/android/android.go
@@ -110,7 +110,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 		}
 
 		// check if is in date range
-		if entries.Entry().ModifiedAt.Before(params.DateRange[0]) || entries.Entry().ModifiedAt.After(params.DateRange[0]) {
+		if !utils.IsValidDate(entries.Entry().ModifiedAt) {
 			continue
 		}
 

--- a/pkg/dji/dji.go
+++ b/pkg/dji/dji.go
@@ -110,7 +110,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 					// check if is in date range
 
-					if d.Before(params.DateRange[0]) || d.After(params.DateRange[1]) {
+					if !utils.IsValidDate(d) {
 						return godirwalk.SkipThis
 					}
 

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -213,9 +213,7 @@ func ImportConnect(params utils.ImportParams) (*utils.Result, error) {
 					continue
 				}
 				tm := time.Unix(i, 0).UTC()
-				start := params.DateRange[0]
-				end := params.DateRange[1]
-				zoneName, _ := end.Zone()
+				zoneName, _ := utils.DateZone()
 				newTime := strings.Replace(tm.Format(time.UnixDate), "UTC", zoneName, -1)
 				tm, _ = time.Parse(time.UnixDate, newTime)
 				mediaDate := tm.Format("02-01-2006")
@@ -224,7 +222,7 @@ func ImportConnect(params utils.ImportParams) (*utils.Result, error) {
 					mediaDate = tm.Format(utils.DateFormatReplacer.Replace(params.DateFormat))
 				}
 
-				if tm.Before(start) || tm.After(end) {
+				if !utils.IsValidDate(tm) {
 					continue
 				}
 

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -162,7 +162,7 @@ folderLoop:
 					d := getFileTime(osPathname, true)
 					mediaDate := getMediaDate(getFileTime(osPathname, true), params.DateFormat)
 
-					if d.Before(params.DateRange[0]) || d.After(params.DateRange[1]) {
+					if !utils.IsValidDate(d) {
 						return godirwalk.SkipThis
 					}
 
@@ -339,7 +339,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 					d := getFileTime(osPathname, true)
 					mediaDate := getMediaDate(d, params.DateFormat)
 
-					if d.Before(params.DateRange[0]) || d.After(params.DateRange[1]) {
+					if !utils.IsValidDate(d) {
 						return godirwalk.SkipThis
 					}
 

--- a/pkg/insta360/insta360.go
+++ b/pkg/insta360/insta360.go
@@ -105,7 +105,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 					// check if is in date range
 
-					if d.Before(params.DateRange[0]) || d.After(params.DateRange[1]) {
+					if !utils.IsValidDate(d) {
 						return godirwalk.SkipThis
 					}
 

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -332,5 +332,3 @@ func GetNewBar(progressBar *mpb.Progress, total int64, filename string, barType 
 		),
 	)
 }
-
-var DateFormatReplacer = strings.NewReplacer("dd", "02", "mm", "01", "yyyy", "2006")

--- a/pkg/utils/import.go
+++ b/pkg/utils/import.go
@@ -1,6 +1,10 @@
 package utils
 
-import "time"
+import (
+	"log"
+	"strings"
+	"time"
+)
 
 type ImportParams struct {
 	Input, Output, CameraName string
@@ -8,7 +12,6 @@ type ImportParams struct {
 	DateFormat                string
 	BufferSize                int
 	Prefix                    string
-	DateRange                 []time.Time
 	TagNames                  []string
 	Connection                ConnectionType
 	Sort                      SortOptions
@@ -16,4 +19,59 @@ type ImportParams struct {
 
 type Import interface {
 	Import(params ImportParams) (*Result, error)
+}
+
+var (
+	dateEnd            time.Time
+	dateStart          time.Time
+	DateFormatReplacer = strings.NewReplacer("dd", "02", "mm", "01", "yyyy", "2006")
+)
+
+func ParseDateRange(dateRange []string, dateFormat string) {
+	if len(dateRange) == 1 {
+		today := time.Date(dateEnd.Year(), dateEnd.Month(), dateEnd.Day(), 0, 0, 0, 0, dateEnd.Location())
+		switch dateRange[0] {
+		case "today":
+			dateStart = today
+		case "yesterday":
+			dateStart = today.Add(-24 * time.Hour)
+		case "week":
+			dateStart = today.Add(-24 * time.Duration((int(dateEnd.Weekday()) - 1)) * time.Hour)
+		case "week-back":
+			dateStart = today.Add(-24 * 7 * time.Hour)
+		}
+	}
+
+	if len(dateRange) == 2 {
+		start, err := time.Parse(DateFormatReplacer.Replace(dateFormat), dateRange[0])
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		if err == nil {
+			dateStart = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
+		}
+		end, err := time.Parse(DateFormatReplacer.Replace(dateFormat), dateRange[1])
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		if err == nil {
+			dateEnd = time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
+		}
+	}
+}
+
+func IsValidDate(tm time.Time) bool {
+	if (!dateStart.IsZero() && tm.Before(dateStart)) || (!dateEnd.IsZero() && tm.After(dateEnd)) {
+		return false
+	}
+
+	return true
+}
+
+func DateZone() (string, int) {
+	if dateEnd.IsZero() {
+		return time.Now().Zone()
+	}
+
+	return dateEnd.Zone()
 }


### PR DESCRIPTION
It can happen and it has happened to me, that the date of the videos recorded by the gopro is in the future and now they are not imported

I have created a function to group the check of date ranges and it only checks the dates in case they contain any value
### Type:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [ ] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


