### PR TITLE
keeps the time of imported files

### DIFF
--- a/pkg/dji/dji.go
+++ b/pkg/dji/dji.go
@@ -134,7 +134,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 						go func(filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", filename), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", filename), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)
@@ -154,7 +154,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 						go func(filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", filename), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", filename), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)
@@ -180,7 +180,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 						go func(filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", extraPath, filename), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", extraPath, filename), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)
@@ -199,7 +199,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 
 						go func(filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos/raw", filename), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos/raw", filename), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -197,7 +197,7 @@ folderLoop:
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -222,7 +222,7 @@ folderLoop:
 
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							_ = parse(folder, filename, osPathname, params.BufferSize, bar)
+							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
 						}(folder, filename, lrvFullpath, proxyVideoBar)
 					case Photo:
 						additionalDir := ""
@@ -232,7 +232,7 @@ folderLoop:
 						folder := filepath.Join(dayFolder, "photos", additionalDir)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -248,7 +248,7 @@ folderLoop:
 						folder := filepath.Join(dayFolder, "multishot", additionalDir, de.Name()[:4])
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -260,7 +260,7 @@ folderLoop:
 						folder := filepath.Join(dayFolder, "photos/raw")
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -272,7 +272,7 @@ folderLoop:
 						folder := filepath.Join(dayFolder, "audios")
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -379,7 +379,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -402,7 +402,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							_ = parse(folder, filename, osPathname, params.BufferSize, bar)
+							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
 						}(folder, x, lrvFullpath, proxyVideoBar)
 
 					case ChapteredVideo:
@@ -426,7 +426,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -449,13 +449,13 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							_ = parse(folder, filename, osPathname, params.BufferSize, bar)
+							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
 						}(folder, x, lrvFullpath, proxyVideoBar)
 					case Photo:
 						folder := filepath.Join(dayFolder, "photos")
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -470,7 +470,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 						folder := filepath.Join(dayFolder, "videos/proxy")
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -482,7 +482,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 						folder := filepath.Join(dayFolder, "multishot", de.Name()[:4])
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -494,7 +494,7 @@ func importFromGoProV1(params utils.ImportParams) utils.Result {
 						folder := filepath.Join(dayFolder, "photos/raw")
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
-							err := parse(folder, filename, osPathname, params.BufferSize, bar)
+							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
 							if err != nil {
 								inlineCounter.SetFailure(err, filename)
 							} else {
@@ -573,7 +573,7 @@ func getMediaDate(d time.Time, dateFormat string) string {
 	return mediaDate
 }
 
-func parse(folder string, name string, osPathname string, bufferSize int, bar *mpb.Bar) error {
+func parse(folder string, name string, osPathname string, bufferSize int, bar *mpb.Bar, modTime time.Time) error {
 	if _, err := os.Stat(folder); os.IsNotExist(err) {
 		mkdirerr := os.MkdirAll(folder, 0o755)
 		if mkdirerr != nil {
@@ -585,7 +585,7 @@ func parse(folder string, name string, osPathname string, bufferSize int, bar *m
 		return err
 	}
 
-	err = utils.CopyFile(osPathname, filepath.Join(folder, name), bufferSize, bar)
+	err = utils.CopyFile(osPathname, filepath.Join(folder, name), bufferSize, bar, modTime)
 	if err != nil {
 		bar.EwmaSetCurrent(sourceFileStat.Size(), 1*time.Millisecond)
 		bar.EwmaIncrInt64(sourceFileStat.Size(), 1*time.Millisecond)

--- a/pkg/insta360/insta360.go
+++ b/pkg/insta360/insta360.go
@@ -133,7 +133,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 						go func(id, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
 
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", id, x), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", id, x), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)
@@ -171,7 +171,7 @@ func (Entrypoint) Import(params utils.ImportParams) (*utils.Result, error) {
 						go func(id, filename, osPathname string, bar *mpb.Bar) {
 							defer wg.Done()
 
-							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, slug, id, x), params.BufferSize, bar)
+							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, slug, id, x), params.BufferSize, bar, d)
 							if err != nil {
 								bar.EwmaSetCurrent(info.Size(), 1*time.Millisecond)
 								bar.EwmaIncrInt64(info.Size(), 1*time.Millisecond)

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -79,7 +79,7 @@ const (
 	Connect ConnectionType = "connect"
 )
 
-func CopyFile(src string, dst string, buffersize int, progressbar *mpb.Bar) error {
+func CopyFile(src string, dst string, buffersize int, progressbar *mpb.Bar, modTime time.Time) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -141,6 +141,11 @@ func CopyFile(src string, dst string, buffersize int, progressbar *mpb.Bar) erro
 		if _, err := destination.Write(buf[:n]); err != nil {
 			return err
 		}
+	}
+
+	err = os.Chtimes(dst, modTime, modTime)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the import process when creating the files does not keep the date of the original file

### Type:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [ ] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


