### PR TITLE
apply the mtime given by the gopro to the written files

### DIFF
--- a/pkg/gopro/update.go
+++ b/pkg/gopro/update.go
@@ -57,7 +57,7 @@ func UpdateCamera(sdcard string) error {
 			color.Yellow(">> Firmware release date: %s", camera.ReleaseDate)
 			color.Yellow(html2text.HTML2Text(camera.ReleaseHTML))
 
-			err = utils.DownloadFile(filepath.Join(sdcard, "UPDATE.zip"), camera.URL, nil)
+			err = utils.DownloadFile(filepath.Join(sdcard, "UPDATE.zip"), camera.URL, nil, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/insta360/update.go
+++ b/pkg/insta360/update.go
@@ -42,7 +42,7 @@ func UpdateCamera(sdcard string, model string) error {
 				color.White(html2text.HTML2Text(item.Description))
 
 				fwURL := item.Channels[0].DownloadURL
-				err = utils.DownloadFile(filepath.Join(sdcard, strings.Split(fwURL, "/")[len(strings.Split(fwURL, "/"))-1]), fwURL, nil)
+				err = utils.DownloadFile(filepath.Join(sdcard, strings.Split(fwURL, "/")[len(strings.Split(fwURL, "/"))-1]), fwURL, nil, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/utils/cameras.go
+++ b/pkg/utils/cameras.go
@@ -172,7 +172,7 @@ func (wc WriteCounter) PrintProgress() {
 	fmt.Printf("\rDownloading... %s complete", humanize.Bytes(wc.Total))
 }
 
-func DownloadFile(filepath string, url string, progressbar *mpb.Bar) error {
+func DownloadFile(filepath string, url string, progressbar *mpb.Bar, mtime *time.Time) error {
 	// Create the file, but give it a tmp file extension, this means we won't overwrite a
 	// file until it's downloaded, but we'll remove the tmp extension once downloaded.
 	out, err := os.Create(filepath + ".tmp")
@@ -208,6 +208,13 @@ func DownloadFile(filepath string, url string, progressbar *mpb.Bar) error {
 
 	// Close the file without defer so it can happen before Rename()
 	out.Close()
+
+	if mtime != nil {
+		// set file mtime to what was given to us
+		if err := os.Chtimes(filepath+".tmp", time.Time{}, *mtime); err != nil {
+			return err
+		}
+	}
 
 	return os.Rename(filepath+".tmp", filepath)
 }


### PR DESCRIPTION


# set the mtime of downloaded files

The gopro already tells us what the mtime of the files should be, so we should set the mtime of our newly mades copies to the respective timestamp.

This allows applications like Google Photos to have the actual timestamp available, when the file was written, instead of reading the timestamp when the files were downloaded from the camera.

Please be aware that this is the first time I'm ever handling golang code, so if any of this is not acceptable or not in proper style please tell me - I'm currently in the "I know barely enough to be dangerous" phase. ;)

### Type:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [x] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [x] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


