### PR TITLE
make HTTP retry when the GoPro is overwhelmed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,8 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/gookit/color v1.2.9 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,9 +245,12 @@ github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -257,6 +260,8 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 func timeoutFromConfig() int {
@@ -13,6 +14,11 @@ func timeoutFromConfig() int {
 	return viper.GetInt(key)
 }
 
-var Client = &http.Client{
-	Timeout: time.Duration(timeoutFromConfig()) * time.Second,
+var Client *http.Client
+
+func init () {
+	var retryableClient = retryablehttp.NewClient()
+	retryableClient.Logger = nil
+	Client = retryableClient.StandardClient()
+
 }

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/spf13/viper"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/spf13/viper"
 )
 
 func timeoutFromConfig() int {
@@ -16,9 +16,12 @@ func timeoutFromConfig() int {
 
 var Client *http.Client
 
-func init () {
-	var retryableClient = retryablehttp.NewClient()
+func init() {
+	retryableClient := retryablehttp.NewClient()
 	retryableClient.Logger = nil
+	retryableClient.Backoff = retryablehttp.LinearJitterBackoff
+	timeout := time.Duration(timeoutFromConfig()) * time.Second
+	retryableClient.RetryWaitMin = timeout / 10
+	retryableClient.RetryWaitMax = timeout
 	Client = retryableClient.StandardClient()
-
 }


### PR DESCRIPTION
# replace net.http with go-retryablehttp

My HERO12 did not like being asked for more than about 5-7 files simultaneously. Instead it dropped some of the /gp/gpMediaMetadata requests with a timeout. So after the files where the call to gpMediaMetadata was successful were downloaded, I got presented with a bunch of errors where it didn't work, and of cause those files were not downloaded.

Switching to a retrying approach means that we still hammer the GoPro for the first couple seconds, but allow the requests to proceed later.

Since go-retryablehttp allows it, I set it up to retry with a lot of jitter, so the camera should not get hit with multiple requests at the same time anymore. I also went for the approach that does not require touching all the points where the pkg/utils/client is used, but instead slipped retryablehttp underneath the `Client` that already was used in all other places.

Please note, as with my other PRs - I'm a beginner at working with golang, and fixed this mainly for me, since it cost me 3 days to import 35GB of footage due to having to retry again and again. So if anything of this jumps out as nonsensical, please tell me.

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


