### PR TITLE
use partition.Mountpoint instead of .Device

### DIFF
--- a/cmd/list_devices.go
+++ b/cmd/list_devices.go
@@ -22,7 +22,7 @@ var listDevicesCmd = &cobra.Command{
 			color.Yellow("📷 Devices:")
 		}
 		for _, partition := range partitions {
-			color.Cyan(fmt.Sprintf("\t🎥 %v (%v)\n", partition.Device, utils.CameraGuess(partition.Device)))
+			color.Cyan(fmt.Sprintf("\t🎥 %v (%v)\n", partition.Mountpoint, utils.CameraGuess(partition.Mountpoint)))
 		}
 
 		ctx := context.Background()

--- a/pkg/gopro/detect.go
+++ b/pkg/gopro/detect.go
@@ -14,8 +14,8 @@ func Detect() (string, utils.ConnectionType, error) {
 		return "", "", err
 	}
 	for _, partition := range partitions {
-		if utils.CameraGuess(partition.Device) == utils.GoPro.ToString() {
-			return partition.Device, utils.SDCard, nil
+		if utils.CameraGuess(partition.Mountpoint) == utils.GoPro.ToString() {
+			return partition.Mountpoint, utils.SDCard, nil
 		}
 	}
 

--- a/pkg/insta360/detect.go
+++ b/pkg/insta360/detect.go
@@ -12,8 +12,8 @@ func Detect() (string, utils.ConnectionType, error) {
 		return "", "", err
 	}
 	for _, partition := range partitions {
-		if utils.CameraGuess(partition.Device) == utils.Insta360.ToString() {
-			return partition.Device, utils.SDCard, nil
+		if utils.CameraGuess(partition.Mountpoint) == utils.Insta360.ToString() {
+			return partition.Mountpoint, utils.SDCard, nil
 		}
 	}
 	return "", "", mErrors.ErrNoCameraDetected


### PR DESCRIPTION
# use partition.Mountpoint instead of .Device

Under Windows both properties carry the same value, yet under Linux .Device is the name of the block device like /dev/sdc1 and mountpoint is the place in the filesystem where this device is mounted and where one can access the data in it - like /mnt/insta-sdcard.

Hence when trying to access files like MISC/version.txt, DCIM/fileinfo_list.list or MISC/GIS/dji.gis it will not work.

Switching to .Mountpoint means file access under Linux will start to work, and keep working under Windows.

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [X] Insta360
- [X] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


