### PR TITLE
make GetFlagString() process the default string

### DIFF
--- a/cmd/apply_lut.go
+++ b/cmd/apply_lut.go
@@ -88,14 +88,14 @@ var applyLutCmd = &cobra.Command{
 	Use:   "apply-lut",
 	Short: "Apply LUT to one or more images",
 	Run: func(cmd *cobra.Command, _ []string) {
-		input := getFlagString(cmd, "input")
-		lutFile := getFlagString(cmd, "lut")
+		input := getFlagString(cmd, "input", "")
+		lutFile := getFlagString(cmd, "lut", "")
 
 		intensity := getFlagInt(cmd, "intensity", "100")
 		intensityParsed := float64(intensity) / 100
 
 		quality := getFlagInt(cmd, "quality", "100")
-		resizeTo := getFlagString(cmd, "resize")
+		resizeTo := getFlagString(cmd, "resize", "")
 
 		stat, err := os.Stat(input)
 		if err != nil {

--- a/cmd/export_tags.go
+++ b/cmd/export_tags.go
@@ -91,9 +91,9 @@ var exportTags = &cobra.Command{
 	Use:   "export-tags",
 	Short: "Export HiLight/other tags in video",
 	Run: func(cmd *cobra.Command, _ []string) {
-		input := getFlagString(cmd, "input")
-		format := getFlagString(cmd, "format")
-		output := getFlagString(cmd, "output")
+		input := getFlagString(cmd, "input", "")
+		format := getFlagString(cmd, "format", "")
+		output := getFlagString(cmd, "output", "")
 
 		stat, err := os.Stat(input)
 		if err != nil {

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -8,13 +8,16 @@ import (
 	"github.com/spf13/viper"
 )
 
-func getFlagString(cmd *cobra.Command, name string) string {
+func getFlagString(cmd *cobra.Command, name string, defaultString string) string {
 	value, err := cmd.Flags().GetString(name)
 	if err != nil {
 		cui.Error("Problem parsing "+name, err)
 	}
 	if value == "" {
 		value = viper.GetString(name)
+	}
+	if value == "" {
+		value = defaultString
 	}
 	return value
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -25,10 +25,10 @@ var importCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Import media",
 	Run: func(cmd *cobra.Command, _ []string) {
-		input := getFlagString(cmd, "input")
-		output := getFlagString(cmd, "output")
-		camera := getFlagString(cmd, "camera")
-		projectName := getFlagString(cmd, "name")
+		input := getFlagString(cmd, "input", "")
+		output := getFlagString(cmd, "output", "")
+		camera := getFlagString(cmd, "camera", "")
+		projectName := getFlagString(cmd, "name", "")
 
 		if projectName != "" {
 			_, err := os.Stat(filepath.Join(output, projectName))
@@ -40,12 +40,12 @@ var importCmd = &cobra.Command{
 			}
 		}
 
-		dateFormat := getFlagString(cmd, "date")
+		dateFormat := getFlagString(cmd, "date", "dd-mm-yyyy")
 		bufferSize := getFlagInt(cmd, "buffer", "1000")
-		prefix := getFlagString(cmd, "prefix")
+		prefix := getFlagString(cmd, "prefix", "")
 		dateRange := getFlagSlice(cmd, "range")
-		cameraName := getFlagString(cmd, "camera-name")
-		connection := utils.ConnectionType(getFlagString(cmd, "connection"))
+		cameraName := getFlagString(cmd, "camera-name", "")
+		connection := utils.ConnectionType(getFlagString(cmd, "connection", ""))
 		skipAuxFiles := getFlagBool(cmd, "skip-aux", "true")
 		sortBy := getFlagSlice(cmd, "sort-by")
 		if len(sortBy) == 0 {
@@ -137,7 +137,7 @@ func init() {
 	importCmd.Flags().StringP("output", "o", "", "Output directory for sorted media")
 	importCmd.Flags().StringP("name", "n", "", "Project name")
 	importCmd.Flags().StringP("camera", "c", "", "Camera type")
-	importCmd.Flags().StringP("date", "d", "dd-mm-yyyy", "Date format, dd-mm-yyyy by default")
+	importCmd.Flags().StringP("date", "d", "", "Date format, dd-mm-yyyy by default")
 	importCmd.Flags().StringP("buffer", "b", "", "Buffer size for copying, default is 1000 bytes")
 	importCmd.Flags().StringP("prefix", "p", "", "Prefix for each file, pass `cameraname` to prepend the camera name (eg: Hero9 Black)")
 	importCmd.Flags().StringSlice("range", []string{}, "A date range, eg: 01-05-2020,05-05-2020 -- also accepted: `today`, `yesterday`, `week`")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -12,8 +12,8 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update camera firmware",
 	Run: func(cmd *cobra.Command, _ []string) {
-		input := getFlagString(cmd, "input")
-		camera := getFlagString(cmd, "camera")
+		input := getFlagString(cmd, "input", "")
+		camera := getFlagString(cmd, "camera", "")
 		c, err := utils.CameraGet(camera)
 		if err != nil {
 			cui.Error("Something went wrong", err)
@@ -25,7 +25,7 @@ var updateCmd = &cobra.Command{
 				cui.Error("Something went wrong", err)
 			}
 		case utils.Insta360:
-			model := getFlagString(cmd, "model")
+			model := getFlagString(cmd, "model", "")
 			err = insta360.UpdateCamera(input, model)
 			if err != nil {
 				cui.Error("Something went wrong", err)


### PR DESCRIPTION
Original PR here: https://github.com/KonradIT/mmt/pull/127

# make GetFlagString() process the default value, not Cobra

since the dateFormat / --date has a default set to dd-mm-yyy, the GetFlagString() function does not ever attempt reading the value from the config file.

Now every GetFlagString() invocation explicitly lists the default values, like GetFlagInt() does, hence one can set  the date format in the config file.

### Type:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [x] GoPro
- [x] Insta360
- [x] DJI
- [x] Android
- [ ] This PR adds a new camera

### Component:

- [x] Core logic
- [ ] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


