### PR TITLE
Add support for insta360 x4

### DIFF
--- a/pkg/insta360/insta360.go
+++ b/pkg/insta360/insta360.go
@@ -28,12 +28,13 @@ func getDeviceName(manifest string) string {
 		return name
 	}
 
-	endBytes := []byte{0x1A, 0x0F}
+	endBytes := []byte{0x1A}
 
 	res := bytes.Split(file, append([]byte{0x12, 0x0B}, []byte("Insta360")...))
 	if len(res) == 1 {
 		return name
 	}
+
 	modelName := bytes.Split(res[1], endBytes)
 	if len(modelName) == 1 {
 		return name


### PR DESCRIPTION
# Add support for insta360 x4

Now the `getDeviceName()` function works properly.

Closes #138

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [X] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


