### PR TITLE
fix: fix gorelease build file

### DIFF
--- a/.github/workflows/build-artifacts.yaml
+++ b/.github/workflows/build-artifacts.yaml
@@ -2,8 +2,8 @@ name: Build and release artifacts
 
 on:
   release:
-    tags:
-      - 'v*'
+    types: [published]
+
 permissions:
   contents: write
 jobs:
@@ -20,7 +20,7 @@ jobs:
           cache: true
       - uses: goreleaser/goreleaser-action@v4          # run goreleaser
         with:
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: mmt
 builds:
   - env: [CGO_ENABLED=0]


### PR DESCRIPTION
# [Fix build files]

The builds were failing because and removed flag `--rm-dist`, this was [deprecated](https://goreleaser.com/deprecations/?h=rm#build) and removed and since the build was using latest it start to fail. 

Changes 

- Update --rm-dist to --clean 
- fix version to '~> v2' avoiding major updates and break changes
- fix gorelase warning `only version: 2 configuration files are supported, yours is version: 0, please update your configuration` by setting  `version: 2` 
- fix github action to use on-> release-> type, tags are only available on [push events](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs), the pipelines were triggered 3 times by the release events types, release.published and released. One succeed and the other filled because the files already exists. 

## Tests

tested pipeline -> https://github.com/EwertonLuan/mmt/actions/runs/15097824341
release with binaries -> https://github.com/EwertonLuan/mmt/releases/tag/v2.0.4


Closes #146 

[Brief description of the fix.]

### Type:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [ ] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [ ] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


