### PR TITLE
Max2 360 photo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ This tool draws inspiration from my [dji-utils/offload.sh](https://github.com/Ko
     - MAX
     - HERO6 - HERO13
     - HERO 2024
+    - MAX2
 -   Insta360: X2, GO2, X3, X4
 -   DJI:
     - Mavic drones (tested with Air 2, Air 2S, Mini 3 Pro, Mavic 3)
     - Osmo Action cameras (tested with Action 3)
     - Osmo Pocket cameras (tested with Pocket 1)
+    - Osmo Nano camera
 -   Android: All, but with Pixel 6 (Google Camera) specific fixes
 - Autel Lite drone
 

--- a/pkg/gopro/filetypes.go
+++ b/pkg/gopro/filetypes.go
@@ -70,6 +70,12 @@ var FileTypeMatches = map[Type][]FileTypeMatch{
 			Type:     Multishot,
 			HeroMode: false,
 		},
+		// MAX 2:
+		{
+			Regex:    regexp.MustCompile(`^GS_+\d+\.36P$`),
+			Type:     Photo,
+			HeroMode: false,
+		},
 	},
 	V1: {
 		{


### PR DESCRIPTION
# Add support for MAX2 .36P photos

Closes #151

.36P are a new file format from GoPro.

>.36P files (default, compatible with GoPro apps for the better viewing and editing)

per the manual.

### Type:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


