### PR TITLE
Fix the hang when ffprobe is missing

### DIFF
--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -399,6 +399,8 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 
 						rawPhotoTotal, err := head(fmt.Sprintf("http://%s:8080/videos/DCIM/%s/%s", params.Input, folder.D, rawPhotoName))
 						if err != nil {
+							wg.Done()
+
 							continue
 						}
 
@@ -467,6 +469,7 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 						err = caller(ctx, params.Input, fmt.Sprintf("gp/gpMediaMetadata?p=%s/%s&t=v4info", folder.D, filename), gpFileInfo)
 						if err != nil {
 							inlineCounter.SetFailure(err, filename)
+							wg.Done()
 
 							continue
 						}

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -221,6 +221,10 @@ folderLoop:
 
 						rfpsFolder, err := getRfpsFolder(osPathname)
 						if err != nil {
+							inlineCounter.SetFailure(err, filename)
+							bar.Abort(true)
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 
@@ -262,6 +266,8 @@ folderLoop:
 
 						lrvStat, err := os.Stat(lrvFullpath)
 						if err != nil {
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 
@@ -423,6 +429,10 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						s, err := ffprobe.VideoSize(osPathname)
 						if err != nil {
+							inlineCounter.SetFailure(err, de.Name())
+							bar.Abort(true)
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 
@@ -462,6 +472,8 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						lrvStat, err := os.Stat(lrvFullpath)
 						if err != nil {
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 
@@ -479,6 +491,10 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						s, err := ffprobe.VideoSize(osPathname)
 						if err != nil {
+							inlineCounter.SetFailure(err, de.Name())
+							bar.Abort(true)
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 
@@ -518,6 +534,8 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						lrvStat, err := os.Stat(lrvFullpath)
 						if err != nil {
+							wg.Done()
+
 							return godirwalk.SkipThis
 						}
 


### PR DESCRIPTION
# Fix the hang when ffprobe is missing

Closes #(issue)

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [X] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


