### PR TITLE
Use workers to limit the files imported at once

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -44,6 +44,7 @@ var importCmd = &cobra.Command{
 
 		dateFormat := getFlagString(cmd, "date", "dd-mm-yyyy")
 		bufferSize := getFlagInt(cmd, "buffer", "1000")
+		maxConcurrent := getFlagInt(cmd, "concurrent", "10")
 		prefix := getFlagString(cmd, "prefix", "")
 		dateRange := getFlagSlice(cmd, "range")
 		cameraName := getFlagString(cmd, "camera-name", "")
@@ -132,6 +133,7 @@ var importCmd = &cobra.Command{
 				SkipAuxiliaryFiles: skipAuxFiles,
 				DateFormat:         dateFormat,
 				BufferSize:         bufferSize,
+				MaxConcurrent:      maxConcurrent,
 				Prefix:             prefix,
 				DateRange:          dateRangeParsed,
 				TagNames:           tagNames,
@@ -187,6 +189,7 @@ func init() {
 	importCmd.Flags().StringSlice("sort-by", []string{}, "Sort files by: `camera`, `location`")
 	importCmd.Flags().StringSlice("tag-names", []string{}, "Tag names for number of HiLight tags in last 10s of video, each position being the amount, eg: 'marked 1,good stuff,important' => num of tags: 1,2,3")
 	importCmd.Flags().StringP("skip-aux", "s", "true", "Skip auxiliary files (GoPro: THM, LRV. DJI: SRT)")
+	importCmd.Flags().String("concurrent", "10", "Maximum number of files to copy concurrently")
 	importCmd.Flags().String("camera-name", "", "Override camera name detection with specified string")
 
 	// Camera helpers

--- a/pkg/android/android.go
+++ b/pkg/android/android.go
@@ -131,6 +131,7 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -209,7 +210,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 			localPath = filepath.Join(dayFolder, "photos", entries.Entry().Name)
 		}
 
+		sem <- struct{}{}
+
 		go func(filename, localPath string, bar *mpb.Bar) {
+			defer func() { <-sem }()
 			defer wg.Done()
 
 			readfile, err = device.OpenRead("/sdcard/DCIM/Camera/" + filename)

--- a/pkg/camera/types.go
+++ b/pkg/camera/types.go
@@ -34,11 +34,18 @@ type ImportParams struct {
 	SkipAuxiliaryFiles        bool
 	DateFormat                string
 	BufferSize                int
+	MaxConcurrent             int
 	Prefix                    string
 	DateRange                 []time.Time
 	TagNames                  []string
 	Connection                ConnectionType
 	Sort                      SortOptions
+}
+
+// NewSemaphore returns a buffered channel used as a counting semaphore to
+// limit concurrent file operations.
+func NewSemaphore(maxConcurrent int) chan struct{} {
+	return make(chan struct{}, maxConcurrent)
 }
 
 // Result holds the outcome of an import operation.

--- a/pkg/dji/dji.go
+++ b/pkg/dji/dji.go
@@ -83,6 +83,7 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -136,7 +137,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", filename), params.BufferSize, bar, d)
@@ -155,7 +159,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", filename), params.BufferSize, bar, d)
@@ -182,7 +189,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "videos", extraPath, filename), params.BufferSize, bar, d)
@@ -200,7 +210,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos/raw", filename), params.BufferSize, bar, d)

--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -217,6 +217,7 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -258,7 +259,10 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 
 				switch fileTypeMatch.Type {
 				case Video, ChapteredVideo:
+					sem <- struct{}{}
+
 					go func(in, folder, origFilename, unsorted string, origSize int64, lrvSize int, bar *mpb.Bar, mtime time.Time) {
+						defer func() { <-sem }()
 						defer wg.Done()
 
 						x := origFilename
@@ -415,7 +419,10 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 					}
 
 					for _, item := range totalPhotos {
+						sem <- struct{}{}
+
 						go func(in string, nowPhoto photo, unsorted string, mtime time.Time) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := utils.DownloadFile(
@@ -476,7 +483,10 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 
 						multiShotBar := camera.GetNewBar(progressBar, gpFileInfo.S, filename, camera.IoTX)
 
+						sem <- struct{}{}
+
 						go func(in, folder, origFilename, unsorted string, origSize int64, mtime time.Time) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := utils.DownloadFile(

--- a/pkg/gopro/gopro.go
+++ b/pkg/gopro/gopro.go
@@ -172,6 +172,7 @@ func importFromGoProV2(params camera.ImportParams) camera.Result {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -242,7 +243,11 @@ folderLoop:
 						}
 
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -273,7 +278,10 @@ folderLoop:
 
 						proxyVideoBar := camera.GetNewBar(progressBar, lrvStat.Size(), lrvReplacer.Replace(de.Name()), camera.IoTX)
 
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -285,7 +293,11 @@ folderLoop:
 						}
 
 						folder := filepath.Join(dayFolder, "photos", additionalDir)
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -303,7 +315,11 @@ folderLoop:
 						}
 
 						folder := filepath.Join(dayFolder, "multishot", additionalDir, de.Name()[:4])
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -316,7 +332,11 @@ folderLoop:
 
 					case RawPhoto:
 						folder := filepath.Join(dayFolder, "photos/raw")
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -329,7 +349,11 @@ folderLoop:
 
 					case Audio:
 						folder := filepath.Join(dayFolder, "audios")
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -378,6 +402,7 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -450,7 +475,11 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 						}
 
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -479,7 +508,10 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						proxyVideoBar := camera.GetNewBar(progressBar, lrvStat.Size(), strings.ReplaceAll(de.Name(), ".MP4", ".LRV"), camera.IoTX)
 
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -512,7 +544,11 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 						}
 
 						folder := filepath.Join(dayFolder, "videos", additionalDir, rfpsFolder)
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -541,14 +577,21 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 						proxyVideoBar := camera.GetNewBar(progressBar, lrvStat.Size(), strings.ReplaceAll(de.Name(), ".MP4", ".LRV"), camera.IoTX)
 
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							_ = parse(folder, filename, osPathname, params.BufferSize, bar, d)
 						}(folder, x, lrvFullpath, proxyVideoBar)
 					case Photo:
 						folder := filepath.Join(dayFolder, "photos")
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -565,7 +608,11 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 						}
 
 						folder := filepath.Join(dayFolder, "videos/proxy")
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -578,7 +625,11 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 					case Multishot:
 						folder := filepath.Join(dayFolder, "multishot", de.Name()[:4])
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)
@@ -591,7 +642,11 @@ func importFromGoProV1(params camera.ImportParams) camera.Result {
 
 					case RawPhoto:
 						folder := filepath.Join(dayFolder, "photos/raw")
+
+						sem <- struct{}{}
+
 						go func(folder, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err := parse(folder, filename, osPathname, params.BufferSize, bar, d)

--- a/pkg/insta360/insta360.go
+++ b/pkg/insta360/insta360.go
@@ -94,6 +94,7 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 
 	var wg sync.WaitGroup
 
+	sem := camera.NewSemaphore(params.MaxConcurrent)
 	progressBar := mpb.New(mpb.WithWaitGroup(&wg),
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond))
@@ -150,7 +151,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(id, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, "photos", id, x), params.BufferSize, bar, d)
@@ -190,7 +194,10 @@ func (Entrypoint) Import(params camera.ImportParams) (*camera.Result, error) {
 							return godirwalk.SkipThis
 						}
 
+						sem <- struct{}{}
+
 						go func(id, filename, osPathname string, bar *mpb.Bar) {
+							defer func() { <-sem }()
 							defer wg.Done()
 
 							err = utils.CopyFile(osPathname, filepath.Join(dayFolder, slug, id, x), params.BufferSize, bar, d)


### PR DESCRIPTION
# Use workers to limit the files imported at once

Closes #116

Limits the number of concurrent downloads to whatever is specified in the `--concurrent` flag (Default is 10)

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [X] Insta360
- [X] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass


