### PR TITLE
Fix for MAX2

### DIFF
--- a/pkg/gopro/connect.go
+++ b/pkg/gopro/connect.go
@@ -262,13 +262,14 @@ func ImportConnect(params camera.ImportParams) (*camera.Result, error) {
 
 						x := origFilename
 						filename := origFilename
+						ext := strings.TrimPrefix(filepath.Ext(x), ".")
 
 						if verType == V2 {
-							filename = fmt.Sprintf("%s%s-%s.%s", x[:2], x[4:][:4], x[2:][:2], "MP4")
+							filename = fmt.Sprintf("%s%s-%s.%s", x[:2], x[4:][:4], x[2:][:2], ext)
 						}
 
 						if verType == V1 && chaptered.MatchString(x) {
-							filename = fmt.Sprintf("GOPR%s%s.%s", x[4:][:4], x[2:][:2], "MP4")
+							filename = fmt.Sprintf("GOPR%s%s.%s", x[4:][:4], x[2:][:2], ext)
 						}
 
 						err := utils.DownloadFile(


### PR DESCRIPTION
# Fix for GoPro MAX2 on OpenGoPro

Fix the file extension on imported videos from GoPro MAX2 when used via USB Ethernet OpenGoPro mode

It was importing videos as `.MP4`

### Type:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Camera:

- [X] GoPro
- [ ] Insta360
- [ ] DJI
- [ ] Android
- [ ] This PR adds a new camera

### Component:

- [ ] Core logic
- [X] Import
- [ ] Merging
- [ ] Firmware Update
- [ ] Video Manipulation

### Checklist before approval:

- Linter pass
- Build pass